### PR TITLE
Validate spkac signature

### DIFF
--- a/pkac.go
+++ b/pkac.go
@@ -12,6 +12,7 @@
 package pkac
 
 import (
+	"crypto"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
@@ -31,7 +32,7 @@ type spkacInfo struct {
 	Signature asn1.BitString
 }
 
-func ParseSPKAC(derBytes []byte) (pub interface{}, err error) {
+func ParseSPKAC(derBytes []byte) (pub crypto.PublicKey, err error) {
 
 	var info spkacInfo
 	if _, err = asn1.Unmarshal(derBytes, &info); err != nil {

--- a/pkac_test.go
+++ b/pkac_test.go
@@ -36,7 +36,7 @@ var spkacRSABase64 = `MIICRTCCAS0wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDK/2
 func TestParseSPKAC(t *testing.T) {
 	derBytes, _ := base64.StdEncoding.DecodeString(spkacRSABase64)
 	if _, err := ParseSPKAC(derBytes); err != nil {
-		t.Error("failed to parse SPKAC: %s", err)
+		t.Errorf("failed to parse SPKAC: %s", err)
 	}
 }
 
@@ -45,19 +45,19 @@ func TestCreateCertificateFromSPKAC(t *testing.T) {
 	parentDerBytes, _ := hex.DecodeString(certificateHex)
 	parent, err := x509.ParseCertificates(parentDerBytes)
 	if err != nil {
-		t.Error("failed to parse builtin certificate: %s", err)
+		t.Errorf("failed to parse builtin certificate: %s", err)
 	}
 
 	privateKeyDerBytes, _ := hex.DecodeString(privateKeyHex)
 	private, err := x509.ParsePKCS1PrivateKey(privateKeyDerBytes)
 	if err != nil {
-		t.Error("failed to parse builtin private key: %s", err)
+		t.Errorf("failed to parse builtin private key: %s", err)
 	}
 
 	spkacDerBytes, _ := base64.StdEncoding.DecodeString(spkacRSABase64)
 	public, err := ParseSPKAC(spkacDerBytes)
 	if err != nil {
-		t.Error("failed to parse SPKAC: %s", err)
+		t.Errorf("failed to parse SPKAC: %s", err)
 	}
 
 	notBefore := time.Now()
@@ -78,12 +78,12 @@ func TestCreateCertificateFromSPKAC(t *testing.T) {
 	}
 	certDerBytes, err := x509.CreateCertificate(rand.Reader, template, parent[0], public, private)
 	if err != nil {
-		t.Error("failed to create certificate: %s", err)
+		t.Errorf("failed to create certificate: %s", err)
 	}
 
 	certOut, err := os.Create(path.Join("test", "42.pem"))
 	if err != nil {
-		t.Error("failed to open test/test.pem for writing: %s", err)
+		t.Errorf("failed to open test/test.pem for writing: %s", err)
 	}
 	pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: certDerBytes})
 	certOut.Close()

--- a/pkac_test.go
+++ b/pkac_test.go
@@ -89,3 +89,30 @@ func TestCreateCertificateFromSPKAC(t *testing.T) {
 	certOut.Close()
 
 }
+
+// An SPKAC that can be validated by go (its signatures are made with
+// SHA256 digests; acquired from the google verified access API):
+var spkacRSASHA256Base64 = `MIICgDCCAWgwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCTfSu8d7y5riNS6ri+gyfOOPLsp5YAP7iC9FfHdLPAjFVc9mLbHHDgcU+/17oSEcYCoGYZBsJTkA3Urx53Rkg6XCvLySxfctG6hhp7P4uAfKhydvnE0A2Bem9x8/WCjgRsBn5MhilxPgV3iARIQM48RtG8V1+L8kKUZ3p2z77famE+BMP2j0iU2dzPuoJod8wzfvQhzu++AtCDYFrVnztBXLEIRgQ/jIngcIiPsWWJ7dtXY0GQIF+3JIbb1F9nz+BV5d2LhRKiY0JWyrsgZSiGNtzbEWNQdwhYfxy85LXJYB4AMgJm1yHKQeS/rLbVgcwcCmAMRSI5g3UPRqXK1VkBAgMBAAEWQDMzQTAwRjFGMTBFODhFMUYzMkVBMjY2OTQ5NDUyMTM2NzdFQTA1OTVFNTVDNjAxMEUwMTBGMUQ0QzIzREM0QTQwDQYJKoZIhvcNAQELBQADggEBAEHs5Rc3SZLIAKXphiU3ZtBhoD7xbgD4Z/hdAsMxb3RxmoA6uX3I9LIRDXVf1Q28gDBhZeVwFq3cjqauE5d9tFfp4WzS+RE5eB5v9nHxYU6srhKoqwZA+2k7ykkptFJYsmsP1V0ipi+4znMszu7s75YWlzjeLJJjazM6xsQd3aIE+1jzNOzBPOFHSj6N1689rz7JeFvZU+DTOabz6uWfZBfoLgMTNzedSU/MwmxImwiz1ciuHI1QdNVFqgEAvTSd74/TCqPFS9r36QMEPPikjtA3GmLnRKSrarJDKm88oJPF23JkAxIU7jasTYVHTJfINcL48DGPGhNbzVIdMbU37uw=`
+
+// An SPKAC that has been tampered with:
+var failingSpkacRSASHA256Base64 = `MIICgDCCAWgwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCTfSu8d7y5riNS6ri+gyfOOPLsp5YAP7iC9FfHdLPAjFVc9mLbHHDgcU+/17oSEcYCoGYZBsJTkA3Urx53Rkg6XCvLySxfctG6hhp7P4uAfKhydvnE0A2Bem9x8/WCjgRsBn5MhilxPgV3iARIQM48RtG8V1+L8kKUZ3p2z77famE+BMP2j0iU2dzPuoJod8wzfvQhzu++AtCDYFrVnztBXLEIRgQ/jIngcIiPsWWJ7dtXY0GQIF+3JIbb1F9nz+BV5d2LhRKiY0JWyrsgZSiGNtzbEWNQdwhYfxy85LXJYB4AMgJm1yHKQeS/rLbVgcwcCmAMRSI5g3UPRqXK1VkBAgMBAAEWQDMzQTAwRjFGMTBFODhFMUYzMkVBMjY2OTQ5NDUyMTM2NzdFQTA1OTVFNTVDNjAyMEUwMTBGMUQ0QzIzREM0QTQwDQYJKoZIhvcNAQELBQADggEBAEHs5Rc3SZLIAKXphiU3ZtBhoD7xbgD4Z/hdAsMxb3RxmoA6uX3I9LIRDXVf1Q28gDBhZeVwFq3cjqauE5d9tFfp4WzS+RE5eB5v9nHxYU6srhKoqwZA+2k7ykkptFJYsmsP1V0ipi+4znMszu7s75YWlzjeLJJjazM6xsQd3aIE+1jzNOzBPOFHSj6N1689rz7JeFvZU+DTOabz6uWfZBfoLgMTNzedSU/MwmxImwiz1ciuHI1QdNVFqgEAvTSd74/TCqPFS9r36QMEPPikjtA3GmLnRKSrarJDKm88oJPF23JkAxIU7jasTYVHTJfINcL48DGPGhNbzVIdMbU37uw=`
+
+func TestValidateSPKAC(t *testing.T) {
+	derBytes, _ := base64.StdEncoding.DecodeString(spkacRSASHA256Base64)
+	if _, err := ParseSPKAC(derBytes); err != nil {
+		t.Errorf("Couldn't even parse the SPKAC: %s", err)
+	}
+	if _, err := ValidateSPKAC(derBytes); err != nil {
+		t.Errorf("SPKAC didn't validate: %s", err)
+	}
+}
+
+func TestFailingSPKACValidation(t *testing.T) {
+	derBytes, _ := base64.StdEncoding.DecodeString(failingSpkacRSASHA256Base64)
+	if _, err := ParseSPKAC(derBytes); err != nil {
+		t.Errorf("Couldn't even parse the SPKAC: %s", err)
+	}
+	if pub, err := ValidateSPKAC(derBytes); err == nil {
+		t.Errorf("The SPKAC validated though it should not have: %v", pub)
+	}
+}

--- a/x509.go
+++ b/x509.go
@@ -142,6 +142,11 @@ func parsePublicKey(algo x509.PublicKeyAlgorithm, keyData *publicKeyInfo) (crypt
 	}
 }
 
+func validateSignature(algo x509.SignatureAlgorithm, pub crypto.PublicKey, signed, signature []byte) error {
+	cert := x509.Certificate{PublicKey: pub}
+	return cert.CheckSignature(algo, signed, signature)
+}
+
 // RFC 3279, 2.3 Public Key Algorithms
 //
 // pkcs-1 OBJECT IDENTIFIER ::== { iso(1) member-body(2) us(840)
@@ -172,4 +177,98 @@ func getPublicKeyAlgorithmFromOID(oid asn1.ObjectIdentifier) x509.PublicKeyAlgor
 		return x509.ECDSA
 	}
 	return x509.UnknownPublicKeyAlgorithm
+}
+
+// OIDs for signature algorithms
+//
+// pkcs-1 OBJECT IDENTIFIER ::= {
+//    iso(1) member-body(2) us(840) rsadsi(113549) pkcs(1) 1 }
+//
+//
+// RFC 3279 2.2.1 RSA Signature Algorithms
+//
+// md2WithRSAEncryption OBJECT IDENTIFIER ::= { pkcs-1 2 }
+//
+// md5WithRSAEncryption OBJECT IDENTIFIER ::= { pkcs-1 4 }
+//
+// sha-1WithRSAEncryption OBJECT IDENTIFIER ::= { pkcs-1 5 }
+//
+// dsaWithSha1 OBJECT IDENTIFIER ::= {
+//    iso(1) member-body(2) us(840) x9-57(10040) x9cm(4) 3 }
+//
+// RFC 3279 2.2.3 ECDSA Signature Algorithm
+//
+// ecdsa-with-SHA1 OBJECT IDENTIFIER ::= {
+//	  iso(1) member-body(2) us(840) ansi-x962(10045)
+//    signatures(4) ecdsa-with-SHA1(1)}
+//
+//
+// RFC 4055 5 PKCS #1 Version 1.5
+//
+// sha256WithRSAEncryption OBJECT IDENTIFIER ::= { pkcs-1 11 }
+//
+// sha384WithRSAEncryption OBJECT IDENTIFIER ::= { pkcs-1 12 }
+//
+// sha512WithRSAEncryption OBJECT IDENTIFIER ::= { pkcs-1 13 }
+//
+//
+// RFC 5758 3.1 DSA Signature Algorithms
+//
+// dsaWithSha256 OBJECT IDENTIFIER ::= {
+//    joint-iso-ccitt(2) country(16) us(840) organization(1) gov(101)
+//    csor(3) algorithms(4) id-dsa-with-sha2(3) 2}
+//
+// RFC 5758 3.2 ECDSA Signature Algorithm
+//
+// ecdsa-with-SHA256 OBJECT IDENTIFIER ::= { iso(1) member-body(2)
+//    us(840) ansi-X9-62(10045) signatures(4) ecdsa-with-SHA2(3) 2 }
+//
+// ecdsa-with-SHA384 OBJECT IDENTIFIER ::= { iso(1) member-body(2)
+//    us(840) ansi-X9-62(10045) signatures(4) ecdsa-with-SHA2(3) 3 }
+//
+// ecdsa-with-SHA512 OBJECT IDENTIFIER ::= { iso(1) member-body(2)
+//    us(840) ansi-X9-62(10045) signatures(4) ecdsa-with-SHA2(3) 4 }
+
+var (
+	oidSignatureMD2WithRSA      = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 2}
+	oidSignatureMD5WithRSA      = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 4}
+	oidSignatureSHA1WithRSA     = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 5}
+	oidSignatureSHA256WithRSA   = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 11}
+	oidSignatureSHA384WithRSA   = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 12}
+	oidSignatureSHA512WithRSA   = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 13}
+	oidSignatureDSAWithSHA1     = asn1.ObjectIdentifier{1, 2, 840, 10040, 4, 3}
+	oidSignatureDSAWithSHA256   = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 3, 2}
+	oidSignatureECDSAWithSHA1   = asn1.ObjectIdentifier{1, 2, 840, 10045, 4, 1}
+	oidSignatureECDSAWithSHA256 = asn1.ObjectIdentifier{1, 2, 840, 10045, 4, 3, 2}
+	oidSignatureECDSAWithSHA384 = asn1.ObjectIdentifier{1, 2, 840, 10045, 4, 3, 3}
+	oidSignatureECDSAWithSHA512 = asn1.ObjectIdentifier{1, 2, 840, 10045, 4, 3, 4}
+)
+
+var signatureAlgorithmDetails = []struct {
+	algo       x509.SignatureAlgorithm
+	oid        asn1.ObjectIdentifier
+	pubKeyAlgo x509.PublicKeyAlgorithm
+	hash       crypto.Hash
+}{
+	{x509.MD2WithRSA, oidSignatureMD2WithRSA, x509.RSA, crypto.Hash(0) /* no value for MD2 */},
+	{x509.MD5WithRSA, oidSignatureMD5WithRSA, x509.RSA, crypto.MD5},
+	{x509.SHA1WithRSA, oidSignatureSHA1WithRSA, x509.RSA, crypto.SHA1},
+	{x509.SHA256WithRSA, oidSignatureSHA256WithRSA, x509.RSA, crypto.SHA256},
+	{x509.SHA384WithRSA, oidSignatureSHA384WithRSA, x509.RSA, crypto.SHA384},
+	{x509.SHA512WithRSA, oidSignatureSHA512WithRSA, x509.RSA, crypto.SHA512},
+	{x509.DSAWithSHA1, oidSignatureDSAWithSHA1, x509.DSA, crypto.SHA1},
+	{x509.DSAWithSHA256, oidSignatureDSAWithSHA256, x509.DSA, crypto.SHA256},
+	{x509.ECDSAWithSHA1, oidSignatureECDSAWithSHA1, x509.ECDSA, crypto.SHA1},
+	{x509.ECDSAWithSHA256, oidSignatureECDSAWithSHA256, x509.ECDSA, crypto.SHA256},
+	{x509.ECDSAWithSHA384, oidSignatureECDSAWithSHA384, x509.ECDSA, crypto.SHA384},
+	{x509.ECDSAWithSHA512, oidSignatureECDSAWithSHA512, x509.ECDSA, crypto.SHA512},
+}
+
+func getSignatureDetailsFromOID(oid asn1.ObjectIdentifier) x509.SignatureAlgorithm {
+	for _, details := range signatureAlgorithmDetails {
+		if oid.Equal(details.oid) {
+			return details.algo
+		}
+	}
+	return x509.UnknownSignatureAlgorithm
 }

--- a/x509.go
+++ b/x509.go
@@ -5,6 +5,7 @@
 package pkac
 
 import (
+	"crypto"
 	"crypto/dsa"
 	"crypto/ecdsa"
 	"crypto/elliptic"
@@ -69,7 +70,7 @@ func namedCurveFromOID(oid asn1.ObjectIdentifier) elliptic.Curve {
 	return nil
 }
 
-func parsePublicKey(algo x509.PublicKeyAlgorithm, keyData *publicKeyInfo) (interface{}, error) {
+func parsePublicKey(algo x509.PublicKeyAlgorithm, keyData *publicKeyInfo) (crypto.PublicKey, error) {
 	asn1Data := keyData.PublicKey.RightAlign()
 	switch algo {
 	case x509.RSA:


### PR DESCRIPTION
This PR does a few things, two minor and one kinda major:

* It updates some of the code to use the newer go's types as available (`crypto.PublicKey`, which might not be much use for typechecking but provides an interesting type hint for the user of this package)

 * It fixes a few linter errors in tests - using `t.Errorf`.

* And finally (and majorly), it introduces a function `ValidateSPKAC`, which not only extracts the public key from an SPKAC, but will also validate the signature on it, provided go lets you (it will refuse to validate RSA+MD5 and RSA+MD2 signatures, which I guess is fine, and if you expect those you should probably be using the plain `ParseSPKAC` method.

I've updated docstrings and added two tests (one for a validating signature, and one for a non-validating one, both constructed from the same blob as returned by google's Verified Access API).

I hope you find this change acceptable - please let me know if there's anything that I can adjust (: